### PR TITLE
Fix logging to write to logs/ directory

### DIFF
--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -20,6 +20,7 @@ from tqdm import tqdm
 from dotenv import load_dotenv
 import hydra
 from omegaconf import DictConfig, OmegaConf
+from hydra.utils import get_original_cwd
 
 # Add src to path
 sys.path.append(str(Path(__file__).parent.parent))
@@ -301,8 +302,9 @@ def main(cfg: DictConfig):
     # Log Hydra config
     print("\nConfiguration:\n", OmegaConf.to_yaml(cfg))
 
-    # Setup logging
-    setup_logging(Path("logs") / "evaluation.log")
+    # Setup logging - use get_original_cwd() to write to project root
+    log_file = Path(get_original_cwd()) / "logs" / "evaluation.log"
+    setup_logging(log_file)
 
     # Resolve paths relative to Hydra's working directory
     model_path = Path(cfg.evaluation.model_path).resolve()

--- a/scripts/prepare_data.py
+++ b/scripts/prepare_data.py
@@ -4,6 +4,7 @@ Handles dataset loading, processing, conversion, and saving.
 """
 
 import logging
+import sys
 from pathlib import Path
 from typing import Dict, List, Any
 from datasets import load_dataset, Dataset, DatasetDict
@@ -11,9 +12,14 @@ from dotenv import load_dotenv
 import os
 import hydra
 from omegaconf import DictConfig
+from hydra.utils import get_original_cwd
+
+# Add src to path for imports
+sys.path.append(str(Path(__file__).parent.parent))
+
+from src.utils import setup_logging
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 # Load secrets from .env
 load_dotenv()
@@ -89,6 +95,10 @@ def main(cfg: DictConfig):
     Args:
         cfg: DictConfig loaded from Hydra YAMLs
     """
+    # Setup logging - use get_original_cwd() to write to project root
+    log_file = Path(get_original_cwd()) / "logs" / "prepare_data.log"
+    setup_logging(log_file)
+
     processor = DatasetProcessor(cfg.dataset.name)
     total_samples = cfg.dataset.train_samples + cfg.dataset.test_samples
     dataset = processor.prepare_dataset(total_samples=total_samples, test_size=cfg.dataset.test_samples)


### PR DESCRIPTION
Fixes #12

## Changes

- Fix evaluate.py to use get_original_cwd() for log file path
- Fix prepare_data.py to properly setup logging with get_original_cwd()
- Enhance setup_logging() in utils.py with better formatting and handler management
- Logs now correctly written to logs/ directory in project root:
  - logs/training.log (already correct)
  - logs/evaluation.log (fixed)
  - logs/prepare_data.log (fixed)
  - logs/upload.log (already correct)

## Root Cause

Hydra changes the working directory to timestamped output directories. Without using `get_original_cwd()`, relative paths would be created in the wrong location.

Generated with [Claude Code](https://claude.ai/code)