### PR TITLE
Fix adapter merge issue and add comprehensive tokenizer logging

### DIFF
--- a/config/evaluation/evaluation.yaml
+++ b/config/evaluation/evaluation.yaml
@@ -22,3 +22,7 @@ skip_baseline: false  # Set to true to skip baseline evaluation (faster)
 num_examples: 3  # Number of example predictions to display
 # Save all predictions to results file
 save_predictions: true  # Save detailed predictions to JSON
+
+# Adapter merging options
+merge_adapter: true  # Set to true to merge LoRA adapter into base model (recommended for evaluation)
+set_eval_mode: true  # Set to true to enable evaluation mode (disables dropout)

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -314,14 +314,14 @@ def main(cfg: DictConfig):
     print("="*80)
 
     try:
+        # For inference, always merge adapter if present and set eval mode
         model, tokenizer = ModelSetup.load_trained_model(
             model_path=model_path,
-            adapter_path=adapter_path
+            adapter_path=adapter_path,
+            merge_adapter=True if adapter_path else False,
+            set_eval_mode=True
         )
-        if hasattr(model, "merge_and_unload"):
-            model = model.merge_and_unload()
-        model.eval()
-        
+
         print(f"✅ Model loaded successfully")
     except Exception as e:
         print(f"❌ Failed to load model: {e}")


### PR DESCRIPTION
- Fix bug in evaluate.py: use self.model instead of model for hasattr check
- Add explicit tokenizer length logging in ModelSetup.load_trained_model()
- Add merge_adapter and set_eval_mode parameters to load_trained_model()
- Update evaluation config to support merge_adapter and set_eval_mode flags
- Update evaluate.py to use new parameters from config
- Update inference.py to always merge adapter and set eval mode
- Ensure model.eval() is called consistently when set_eval_mode=True
- Log tokenizer length vs model vocab size for debugging mismatches

This addresses the RuntimeError with token embedding size mismatch (128258 vs 128256) and ensures proper adapter merging for evaluation.

Resolves #16