### PR TITLE
Fix: Explicitly save tokenizer during training for HF upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,46 @@ This codebase uses the **latest TRL API** which requires:
 
 These changes ensure compatibility with the latest versions of `transformers`, `trl`, and `peft` libraries.
 
+## 📦 Model Artifacts
+
+### What Gets Saved During Training
+
+When training completes, the following artifacts are saved to the `output_dir` (default: `code-llama-3-1-8b-text-to-sql`):
+
+**Model Files:**
+- `adapter_config.json` - LoRA adapter configuration
+- `adapter_model.safetensors` - LoRA adapter weights
+- `README.md` - Auto-generated model card (for uploads)
+
+**Tokenizer Files (Critical for Inference):**
+- `tokenizer.json` - Tokenizer vocabulary and merges
+- `tokenizer_config.json` - Tokenizer configuration
+- `special_tokens_map.json` - Special tokens (including chat format tokens)
+- Additional files depending on tokenizer type (e.g., `vocab.json`, `merges.txt`)
+
+**Why Tokenizer Saving Matters:**
+
+The tokenizer is explicitly saved using `tokenizer.save_pretrained()` after training because:
+
+1. **Special Tokens:** Two special tokens are added during training via `setup_chat_format()`. These must be saved for inference.
+2. **Token Mapping:** The tokenizer maps text to token IDs. Without the correct tokenizer, inference produces incorrect results.
+3. **Hugging Face Upload:** The upload script (`scripts/upload_to_hf.py`) expects tokenizer files to be present in the output directory.
+4. **Reproducibility:** Ensures anyone using your model has the exact tokenizer configuration used during training.
+
+**Verification:**
+
+After training, verify tokenizer files exist:
+
+```bash
+ls -la code-llama-3-1-8b-text-to-sql/tokenizer*
+# Should show:
+# tokenizer.json
+# tokenizer_config.json
+# special_tokens_map.json
+```
+
+If tokenizer files are missing, the model upload will fail or the model will be unusable for inference.
+
 ## 📄 License
 
 Apache-2.0 license - see LICENSE file for details

--- a/src/training.py
+++ b/src/training.py
@@ -222,8 +222,14 @@ class ModelTrainer:
         try:
             self.trainer.save_model()
             logger.info("Model saved successfully")
+
+            # Explicitly save tokenizer with special tokens added during training
+            # This ensures tokenizer is available for inference and HF upload
+            logger.info(f"Saving tokenizer to {self.output_dir}")
+            self.tokenizer.save_pretrained(self.output_dir)
+            logger.info(f"Tokenizer saved successfully (vocab size: {len(self.tokenizer)})")
         except Exception as e:
-            logger.error(f"Failed to save model: {e}")
+            logger.error(f"Failed to save model or tokenizer: {e}")
             raise
 
     def cleanup(self) -> None:


### PR DESCRIPTION
## Summary

Fixed issue where tokenizer was not being saved during training, causing incomplete model artifacts for Hugging Face upload.

## Problem

The `ModelTrainer.save_model()` method only saved model weights but not the tokenizer. This meant:
- No tokenizer files in output directory
- Special tokens added during training were lost
- Models uploaded to HF were incomplete and unusable
- Inference failed due to incorrect token mappings

## Solution

Modified `src/training.py` to explicitly call `tokenizer.save_pretrained(output_dir)` after saving the model. This ensures:
- All tokenizer files are saved (tokenizer.json, config, special_tokens_map, etc.)
- Special tokens from `setup_chat_format()` are preserved
- Models can be properly uploaded to Hugging Face
- Inference works correctly with saved tokenizer

## Changes

- `src/training.py`: Added explicit tokenizer saving in `save_model()` method
- `README.md`: Added "Model Artifacts" section documenting what gets saved

## Testing

After training, verify tokenizer files exist:
```bash
ls -la code-llama-3-1-8b-text-to-sql/tokenizer*
# Should show: tokenizer.json, tokenizer_config.json, special_tokens_map.json
```

Fixes #24

---

🤖 Generated with [Claude Code](https://claude.ai/code)