### PR TITLE
Fix chat template initialization error for Instruct models

### DIFF
--- a/config/hf/hf.yaml
+++ b/config/hf/hf.yaml
@@ -5,6 +5,12 @@ model_id: meta-llama/Llama-3.1-8B-Instruct
 token: ${oc.env:HF_TOKEN,null}
 username: chrisjcc
 
+# Model setup configuration
+# Set setup_chat_format to false for Instruct models that already have chat templates
+# Set to true for base models that need chat template setup
+setup_chat_format: false  # Llama-3.1-8B-Instruct already has a chat template
+force_chat_setup: false    # Set to true to force re-applying chat template (not recommended)
+
 # Upload configuration
 upload:
   # What to upload

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -58,10 +58,15 @@ def main(cfg: DictConfig):
 
     # Initialize model and tokenizer
     use_flash_attention = cfg.training.get("use_flash_attention", True)
+    setup_chat_format = cfg.hf.get("setup_chat_format", True)
+    force_chat_setup = cfg.hf.get("force_chat_setup", False)
+
     model, tokenizer, _ = initialize_model_for_training(
         model_id=cfg.hf.model_id,
         use_flash_attention=use_flash_attention,
         max_seq_length=cfg.training.max_seq_length,
+        setup_chat_format=setup_chat_format,
+        force_chat_setup=force_chat_setup,
     )
 
     # Configure LoRA if applicable


### PR DESCRIPTION
### Summary

This PR fixes the ValueError that occurred during training when trying to apply a chat template to models that already have one built-in (like Llama-3.1-8B-Instruct).

### Changes

- **Added smart detection** in `src/model_setup.py` to check if chat template already exists
- **Added config parameters** (`setup_chat_format`, `force_chat_setup`) to control behavior
- **Updated `config/hf/hf.yaml`** to disable chat setup for Llama-3.1-8B-Instruct
- **Updated `scripts/train.py`** to use config parameters

### Testing

After merging, run `make train-accelerate` to verify that:
1. The ValueError no longer occurs
2. Training proceeds beyond model setup phase
3. Logs show "Chat template already present in tokenizer, skipping setup_chat_format()"

Fixes #34

---

Generated with [Claude Code](https://claude.ai/code)