### PR TITLE
Fix: Respect setup_chat_format configuration flags in evaluation pipeline

### DIFF
--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -196,7 +196,9 @@ class ModelEvaluator:
         test_dataset: Dataset,
         batch_size: int = 8,
         temperature: float = 0.0,
-        skip_baseline: bool = False
+        skip_baseline: bool = False,
+        setup_chat_format: bool = True,
+        force_chat_setup: bool = False,
     ):
         """
         Initialize evaluator.
@@ -208,6 +210,8 @@ class ModelEvaluator:
             batch_size: Batch size for generation
             temperature: Sampling temperature for generation (0.0 = greedy)
             skip_baseline: If True, skip baseline evaluation
+            setup_chat_format: Whether to apply chat format setup (default: True)
+            force_chat_setup: If True, force chat setup even if template exists (default: False)
         """
         self.base_model_path = model_name_or_path
         self.adapter_path = adapter_path
@@ -215,6 +219,8 @@ class ModelEvaluator:
         self.batch_size = batch_size
         self.temperature = temperature
         self.skip_baseline = skip_baseline
+        self.setup_chat_format = setup_chat_format
+        self.force_chat_setup = force_chat_setup
         self.model = None
         self.tokenizer = None
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -238,7 +244,9 @@ class ModelEvaluator:
 
         self.model, self.tokenizer = ModelSetup.load_trained_model(
             model_path=self.base_model_path,
-            adapter_path=adapter_path
+            adapter_path=adapter_path,
+            setup_chat_format_flag=self.setup_chat_format,
+            force_chat_setup=self.force_chat_setup,
         )
 
         # Merge adapter into base model if it's a PEFT model
@@ -623,6 +631,8 @@ def main(cfg: DictConfig):
         batch_size=cfg.evaluation.batch_size,
         temperature=cfg.evaluation.temperature,
         skip_baseline=cfg.evaluation.skip_baseline,
+        setup_chat_format=cfg.hf.setup_chat_format,
+        force_chat_setup=cfg.hf.force_chat_setup,
     )
 
     # Show examples (load adapter if available, otherwise base model)

--- a/scripts/inference.py
+++ b/scripts/inference.py
@@ -316,7 +316,9 @@ def main(cfg: DictConfig):
     try:
         model, tokenizer = ModelSetup.load_trained_model(
             model_path=model_path,
-            adapter_path=adapter_path
+            adapter_path=adapter_path,
+            setup_chat_format_flag=cfg.hf.setup_chat_format,
+            force_chat_setup=cfg.hf.force_chat_setup,
         )
         if hasattr(model, "merge_and_unload"):
             model = model.merge_and_unload()


### PR DESCRIPTION
## Summary

Resolves #36 - Fixes evaluation failure caused by chat template conflict during model loading.

## Changes

- Modified `ModelSetup.load_trained_model()` to accept and respect `setup_chat_format_flag` and `force_chat_setup` parameters
- Added conditional logic to skip chat format setup when `setup_chat_format: false` in config
- Updated `ModelEvaluator` and inference script to pass configuration flags
- Added clear logging for when chat setup is skipped

## Testing

The fix ensures that `make evaluate` respects the `setup_chat_format: false` setting in `config/hf/hf.yaml` and no longer attempts to reapply chat templates to models that already have them (e.g., Instruct models).

---

Generated with [Claude Code](https://claude.ai/code)