### PR TITLE
Fix critical bug in evaluation: decode only generated tokens

### DIFF
--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -300,7 +300,13 @@ class ModelEvaluator:
                 stopping_criteria=stopping_criteria,  # Custom stopping criteria
             )
 
-        decoded = self.tokenizer.batch_decode(outputs, skip_special_tokens=True)
+        # CRITICAL FIX: Decode only the newly generated tokens, not the full sequence
+        # The outputs tensor includes both the input prompt and generated tokens
+        # We need to slice off the input portion to get only the model's response
+        input_length = inputs['input_ids'].shape[1]
+        generated_tokens = outputs[:, input_length:]
+
+        decoded = self.tokenizer.batch_decode(generated_tokens, skip_special_tokens=True)
         return [extract_sql(sql) for sql in decoded]
 
     # ----------------------------------------


### PR DESCRIPTION
Fixes #39

### Problem
The `generate_sql_batch` method was incorrectly decoding the entire output sequence (input + generated tokens) instead of just the newly generated tokens. This caused the `extract_sql` function to receive the full chat template, resulting in truncated or empty SQL predictions and 0% accuracy.

### Solution
Fixed by slicing the output tensor to exclude input tokens before decoding:
- Calculate `input_length` from `input_ids` shape
- Slice `outputs[:, input_length:]` to get only generated tokens
- Decode only the generated portion

### Impact
This should resolve the 0% accuracy issue and allow proper evaluation of the fine-tuned model's performance.

----

Generated with [Claude Code](https://claude.ai/code)